### PR TITLE
Interlacing fixes (#182)

### DIFF
--- a/src/interlace.rs
+++ b/src/interlace.rs
@@ -135,6 +135,19 @@ pub fn deinterlace_image(png: &PngImage) -> PngImage {
             if current_pass == 3 && png.ihdr.height <= 4 {
                 current_pass += 1;
             }
+            if current_pass == 4 && png.ihdr.width <= 2 {
+                current_pass += 1;
+            }
+            if current_pass == 5 && png.ihdr.height <= 2 {
+                current_pass += 1;
+            }
+            if current_pass == 6 && png.ihdr.width == 1 {
+                current_pass += 1;
+            }
+            if current_pass == 7 && png.ihdr.height == 1 {
+                break;
+            }
+
             pass_constants = interlaced_constants(current_pass);
             current_y = pass_constants.y_shift as usize;
         }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -635,3 +635,19 @@ fn issue_175() {
         BitDepth::One,
     );
 }
+
+#[test]
+fn issue_182() {
+    let input = "tests/files/issue-175.png";
+    let (output, mut opts) = get_opts(Path::new(input));
+    opts.interlace = Some(0);
+
+    test_it_converts(
+        input,
+        Some((output, opts)),
+        ColorType::Grayscale,
+        BitDepth::One,
+        ColorType::Grayscale,
+        BitDepth::One,
+    );
+}


### PR DESCRIPTION
* Fix decoding interlaced images with height or width <= 2

* Add Issue 175 test case

* Deinterlace tiny images correctly